### PR TITLE
Feature spl expressions

### DIFF
--- a/src/main/scala/org/apache/spark/sql/SplToCatalyst.scala
+++ b/src/main/scala/org/apache/spark/sql/SplToCatalyst.scala
@@ -356,6 +356,7 @@ object SplToCatalyst extends Logging {
   }
 
   private def expression(expr: spl.Expr): Expression = expr match {
+    case field: spl.Field => attr(field)
     case constant: spl.Constant => mapConstants(constant)
     case call: spl.Call => function(call)
     case spl.Unary(symbol, right) => symbol match {
@@ -371,12 +372,12 @@ object SplToCatalyst extends Logging {
     case spl.Binary(left, symbol, right) => symbol match {
       case straight: spl.Straight => straight match {
         case relational: spl.Relational => relational match {
-          case spl.LessThan => LessThan(attr(left), expression(right))
-          case spl.GreaterThan => GreaterThan(attr(left), expression(right))
-          case spl.GreaterEquals => GreaterThanOrEqual(attr(left), expression(right))
-          case spl.LessEquals => LessThanOrEqual(attr(left), expression(right))
-          case spl.Equals => EqualTo(attr(left), expression(right))
-          case spl.NotEquals => Not(EqualTo(attr(left), expression(right)))
+          case spl.LessThan => LessThan(expression(left), expression(right))
+          case spl.GreaterThan => GreaterThan(expression(left), expression(right))
+          case spl.GreaterEquals => GreaterThanOrEqual(expression(left), expression(right))
+          case spl.LessEquals => LessThanOrEqual(expression(left), expression(right))
+          case spl.Equals => EqualTo(expression(left), expression(right))
+          case spl.NotEquals => Not(EqualTo(expression(left), expression(right)))
         }
         case spl.Or => Or(expression(left), expression(right))
         case spl.And => And(expression(left), expression(right))
@@ -404,7 +405,6 @@ object SplToCatalyst extends Logging {
   private def mapConstants(constant: spl.Constant): Literal = constant match {
     case spl.Null() => Literal.create(null)
     case spl.Bool(value) => Literal.create(value)
-    case spl.Field(value) => Literal.create(value)
     case spl.StrValue(value) => Literal.create(value)
     case spl.IntValue(value) => Literal.create(value)
   }

--- a/src/main/scala/spl/SplParser.scala
+++ b/src/main/scala/spl/SplParser.scala
@@ -66,6 +66,7 @@ object SplParser {
     case (sign, i) => IntValue(if (sign.equals("-")) -1 * i.toInt else i.toInt)
   }
 
+  //def constant[_:P]: P[Constant] = cidr | wildcard | strValue | int | bool
   def constant[_:P]: P[Constant] = cidr | wildcard | strValue | int | field | bool
 
   private def ALL[_: P]: P[OperatorSymbol] = (Or.P | And.P | LessThan.P | GreaterThan.P
@@ -97,6 +98,7 @@ object SplParser {
   def call[_: P]: P[Call] = (token ~~ "(" ~~ expr.rep(sep=",") ~~ ")").map(Call.tupled)
 
   def termCall[_: P]: P[Call] = (W("TERM") ~ "(" ~ CharsWhile(!")".contains(_)).! ~ ")").map(term => Call("TERM", Seq(Field(term))))
+  //def argu[_: P]: P[Expr] = termCall | call | field | constant
   def argu[_: P]: P[Expr] = termCall | call | constant
   def parens[_: P]: P[Expr] = "(" ~ expr ~ ")"
   def primary[_: P]: P[Expr] = unaryOf(expr) | fieldIn | parens | argu

--- a/src/main/scala/spl/ast.scala
+++ b/src/main/scala/spl/ast.scala
@@ -12,6 +12,7 @@ case class Null() extends Constant
 case class Bool(value: Boolean) extends Constant
 case class IntValue(value: Int) extends Constant
 case class StrValue(value: String) extends Constant
+//case class Field(value: String) extends Expr with FieldLike
 case class Field(value: String) extends Constant with FieldLike
 case class Wildcard(value: String) extends Constant with FieldLike
 case class IPv4CIDR(value: String) extends Constant {

--- a/src/test/scala/org/apache/spark/sql/SplToCatalystTest.scala
+++ b/src/test/scala/org/apache/spark/sql/SplToCatalystTest.scala
@@ -278,7 +278,7 @@ class SplToCatalystTest extends AnyFunSuite with PlanTestBase {
             ))),
             (_, tree) => {
                 Join(tree,
-                     Filter(Literal("vendors"), tree),
+                     Filter(UnresolvedAttribute("vendors"), tree),
                      UsingJoin(Inner, List("product_id")), None, JoinHint.NONE)
             }
         )
@@ -297,7 +297,7 @@ class SplToCatalystTest extends AnyFunSuite with PlanTestBase {
             ))),
             (_, tree) => {
                 Join(tree,
-                    Filter(Literal("vendors"), tree),
+                    Filter(UnresolvedAttribute("vendors"), tree),
                     UsingJoin(LeftOuter, List("product_id", "product_name")), None, JoinHint.NONE)
             }
         )

--- a/src/test/scala/org/apache/spark/sql/VerificationTest.scala
+++ b/src/test/scala/org/apache/spark/sql/VerificationTest.scala
@@ -70,6 +70,36 @@ class VerificationTest extends AnyFunSuite with ProcessProxy {
         |""".stripMargin)
   }
 
+  test("len(a) < n") {
+    import spark.implicits._
+    spark.createDataset(dummy).createOrReplaceTempView("main")
+    executes("len(a) < n",
+      """+---+---+---+---+-----+
+        ||a  |b  |c  |n  |valid|
+        |+---+---+---+---+-----+
+        ||d  |e  |f  |2  |false|
+        ||g  |h  |i  |3  |true |
+        ||h  |g  |f  |4  |false|
+        ||e  |d  |c  |5  |true |
+        |+---+---+---+---+-----+
+        |""".stripMargin)
+  }
+
+  test("((len(a) < n) AND (len(a) == len(b))") {
+    import spark.implicits._
+    spark.createDataset(dummy).createOrReplaceTempView("main")
+    executes("len(a) < n",
+      """+---+---+---+---+-----+
+        ||a  |b  |c  |n  |valid|
+        |+---+---+---+---+-----+
+        ||d  |e  |f  |2  |false|
+        ||g  |h  |i  |3  |true |
+        ||h  |g  |f  |4  |false|
+        ||e  |d  |c  |5  |true |
+        |+---+---+---+---+-----+
+        |""".stripMargin)
+  }
+
   test("rex \"From: <(?<from>.*)> To: <(?<to>.*)>\"") {
     import spark.implicits._
 


### PR DESCRIPTION
This draft should be the basis for a discussion on how to solve Issue #25 .
Basically, I've added a new termination condition to the recursion of the 'expression' function in  SplToCatalyst.scala. Additionally, recursive calls of this function were added in case we have a binary expression in the input.
Now, it is possible to evaluate expressions like 'len(a) < n' and  '((len(a) < n) AND (len(a) == len(b))'.

However, the implemented approach is not really clean. As of now, the Field class extends the 'Constant' class. In the expression function there was already a termination condition for Constants. If a Field was the input to the expression function, the function would convert the Field value to a Literal (see mapConstants function). This created wrong results.

Imho 'Field' should not extend Constant in the AST. I tried to change it (see commented changes in ast.scala and SplParser.scala) but then some tests break. What do you think? Is there a reason why we declare Field as a Constant? Maybe I did get something wrong....


