### PR TITLE
Reverting publish test steps due to issue with PR from fork

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -31,6 +31,6 @@ jobs:
       - name: Run Tests with Maven
         run: mvn -B test --file pom.xml --fail-at-end
 
-      - name: Publish Tests Report
-        if: ${{ always() }}
-        uses: scacap/action-surefire-report@v1
+#      - name: Publish Tests Report
+#        if: ${{ always() }}
+#        uses: scacap/action-surefire-report@v1


### PR DESCRIPTION
Reverting publish test steps due to issue with PR from fork
see. https://github.com/ScaCap/action-surefire-report/issues/31