### PR TITLE
Add support for `like()` function

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ There's basic support for the most used commands like `addtotals`, `bin`, `colle
 `streamstats`, `table`, `where`.
 
 There's also basic support for functions like `auto()`, `cidr_match()`, `coalesce()`, `count()`, 
-`ctime()`, `earliest()`, `if()`, `isnotnull()`, `latest()`, `len()`, `lower()`, `max()`, 
+`ctime()`, `earliest()`, `if()`, `isnotnull()`, `latest()`, `len()`, `like`, `lower()`, `max()`, 
 `memk()`, `min()`, `mvappend()`, `mvcount()`, `mvfilter()`, `mvindex()`, `none()`, 
 `null()`, `num()`, `replace()`, `rmcomma()`, `rmunit()`, `round()`, `strftime()`, 
 `substr()`, `sum()`, `term()`, `values()`. 

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ There's basic support for the most used commands like `addtotals`, `bin`, `colle
 `streamstats`, `table`, `where`.
 
 There's also basic support for functions like `auto()`, `cidr_match()`, `coalesce()`, `count()`, 
-`ctime()`, `earliest()`, `if()`, `isnotnull()`, `latest()`, `len()`, `like`, `lower()`, `max()`, 
+`ctime()`, `earliest()`, `if()`, `isnotnull()`, `latest()`, `len()`, `like()`, `lower()`, `max()`, 
 `memk()`, `min()`, `mvappend()`, `mvcount()`, `mvfilter()`, `mvindex()`, `none()`, 
 `null()`, `num()`, `replace()`, `rmcomma()`, `rmunit()`, `round()`, `strftime()`, 
 `substr()`, `sum()`, `term()`, `values()`. 

--- a/src/test/scala/com/databricks/labs/transpiler/spl/catalyst/SplToCatalystTest.scala
+++ b/src/test/scala/com/databricks/labs/transpiler/spl/catalyst/SplToCatalystTest.scala
@@ -1096,6 +1096,30 @@ class SplToCatalystTest extends AnyFunSuite with PlanTestBase {
         )
     }
 
+    test("simple LIKE converted to CONTAINS") {
+        check(ast.SearchCommand(
+            ast.Call("like", Seq(ast.Field("a"), ast.StrValue("%foo%")))),
+            (_, tree) =>
+                Filter(
+                    Contains(
+                        UnresolvedAttribute("a"),
+                        Literal.create("foo")),
+                    tree)
+        )
+    }
+
+    test("complex LIKE not converted to CONTAINS") {
+        check(ast.SearchCommand(
+            ast.Call("like", Seq(ast.Field("a"), ast.StrValue("%foo%bar%")))),
+            (_, tree) =>
+                Filter(
+                    Like(
+                        UnresolvedAttribute("a"),
+                        Literal.create("%foo%bar%"), '\\'),
+                    tree)
+        )
+    }
+
     test("eventstats max(colA) AS maxA by colC") {
         check(ast.EventStatsCommand(
             allNum = false,

--- a/src/test/scala/com/databricks/labs/transpiler/spl/catalyst/SplToCatalystTest.scala
+++ b/src/test/scala/com/databricks/labs/transpiler/spl/catalyst/SplToCatalystTest.scala
@@ -1118,6 +1118,15 @@ class SplToCatalystTest extends AnyFunSuite with PlanTestBase {
                         Literal.create("%foo%bar%"), '\\'),
                     tree)
         )
+        check(ast.SearchCommand(
+            ast.Call("like", Seq(ast.Field("a"), ast.StrValue("%foo\\%")))),
+            (_, tree) =>
+                Filter(
+                    Like(
+                        UnresolvedAttribute("a"),
+                        Literal.create("%foo\\%"), '\\'),
+                    tree)
+        )
     }
 
     test("eventstats max(colA) AS maxA by colC") {


### PR DESCRIPTION
Adds support for the `like()` function, converting to a `CONTAINS` filter when possible (to take advantage of predicate pushdown).